### PR TITLE
Fix/keyboard backlight settings preservation

### DIFF
--- a/lib/KeyboardBacklightService.js
+++ b/lib/KeyboardBacklightService.js
@@ -1,3 +1,4 @@
+import GLib from 'gi://GLib';
 import { KeyboardBacklightDbus } from './KeyboardBacklightDbus.js';
 import { IdleMonitorDbus } from './IdleMonitorDbus.js';
 
@@ -35,6 +36,27 @@ export class KeyboardBacklightService {
     return levels;
   }
 
+  // One-time recovery: an earlier prefs bug could write GTK_INVALID_LIST_POSITION
+  // (0xFFFFFFFF) into keyboard-backlight-levels during window close. Replace any
+  // such sentinels with the schema's default for that index (or 0 past its length)
+  // and persist. Idempotent — no-op once gsettings is clean.
+  _migrateCorruptedLevels() {
+    if (!this._backlightLevels?.some((l) => l === 0xffffffff)) return;
+
+    const defaultVariant = this._settings.get_default_value('keyboard-backlight-levels');
+    const defaults = [];
+    for (let i = 0; i < defaultVariant.n_children(); i++) {
+      defaults.push(defaultVariant.get_child_value(i).get_uint32());
+    }
+
+    const cleaned = this._backlightLevels.map((l, i) =>
+      l === 0xffffffff ? (defaults[i] ?? 0) : l
+    );
+
+    this._backlightLevels = cleaned;
+    this._settings.set_value('keyboard-backlight-levels', new GLib.Variant('au', cleaned));
+  }
+
   /**
    * Initialize the service
    * @returns {Promise<boolean>} True if keyboard backlight is available
@@ -55,6 +77,7 @@ export class KeyboardBacklightService {
       );
 
       this._backlightLevels = this._getBacklightLevels();
+      this._migrateCorruptedLevels();
 
       return true;
     } catch (error) {

--- a/preferences/KeyboardBacklightTab.js
+++ b/preferences/KeyboardBacklightTab.js
@@ -64,6 +64,9 @@ export class KeyboardBacklightTab {
 
     if (this.keyboardDropdowns) {
       this.keyboardDropdowns.forEach((item) => {
+        if (item.handlerId) {
+          item.comboRow.disconnect(item.handlerId);
+        }
         this.keyboardGroup.remove(item.comboRow);
       });
     }
@@ -117,11 +120,11 @@ export class KeyboardBacklightTab {
       comboRow.set_model(model);
       comboRow.set_selected(currentLevel);
 
-      comboRow.connect('notify::selected', () => {
+      const handlerId = comboRow.connect('notify::selected', () => {
         this.saveKeyboardBacklightLevels();
       });
 
-      this.keyboardDropdowns.push({ comboRow, bucketIndex: index });
+      this.keyboardDropdowns.push({ comboRow, bucketIndex: index, handlerId });
       this.keyboardGroup.add(comboRow);
     });
   }
@@ -148,7 +151,24 @@ export class KeyboardBacklightTab {
   saveKeyboardBacklightLevels() {
     const levels = this.keyboardDropdowns.map((item) => item.comboRow.get_selected());
 
+    // Guard against GTK_INVALID_LIST_POSITION (0xFFFFFFFF) which can be emitted
+    // via notify::selected during widget disposal when the model is cleared.
+    if (levels.some((l) => l === 0xffffffff)) {
+      return;
+    }
+
     const variant = new GLib.Variant('au', levels);
     this.settings.set_value('keyboard-backlight-levels', variant);
+  }
+
+  destroy() {
+    if (this.keyboardDropdowns) {
+      this.keyboardDropdowns.forEach((item) => {
+        if (item.handlerId) {
+          item.comboRow.disconnect(item.handlerId);
+          item.handlerId = null;
+        }
+      });
+    }
   }
 }

--- a/prefs.js
+++ b/prefs.js
@@ -53,6 +53,7 @@ export default class AdaptiveBrightnessPreferences extends ExtensionPreferences 
     this.currentLux = null;
 
     window.connect('close-request', () => {
+      this.keyboardTab?.destroy();
       this._cleanupSensorProxy();
       this._cleanupKeyboardBacklight();
       if (this._graphBucketsListenerId) {


### PR DESCRIPTION
## Summary

Keyboard backlight levels configured in the prefs window get silently overwritten on window close, so settings appear reset on the next open and the running extension drives the backlight to 100% in any active bucket.

## Root cause

Each `Adw.ComboRow` in `KeyboardBacklightTab` has a `notify::selected` handler that writes the dropdowns' `get_selected()` values back to gsettings. On window close, GTK disposes each row and clears its model, which emits `notify::selected` with `GTK_INVALID_LIST_POSITION` (`0xFFFFFFFF`). The handler then writes `[4294967295, 4294967295, ...]` into the `au` settings key.

On reopen, `set_selected(4294967295)` falls back to the first item so dropdowns just look like "Off". The service, meanwhile, computes `Math.round(100 / (Steps - 1) * 0xFFFFFFFF)`, clamped to 100 — so the keyboard sits at max brightness whenever a bucket is supposed to enable it.

## Fix

- `KeyboardBacklightTab`: track each `notify::selected` handler ID, disconnect before row removal, expose `destroy()` for window close. `prefs.js` calls it from `close-request` before widget disposal can fire stray signals. `saveKeyboardBacklightLevels` also guards against `0xFFFFFFFF` as defense in depth.
- `KeyboardBacklightService.start()`: one-time migration — replace any `0xFFFFFFFF` entries with the schema default at that index (or `0` past its length) and persist.

The migration is needed because users already affected by the bug have the sentinel sitting in their gsettings. Without it, the new save-time guard would block them from re-saving until every dropdown is touched, and the service would keep pinning the backlight to 100% on every launch. The migration is idempotent, so it self-disables on subsequent launches once gsettings is clean.