### PR TITLE
fix: ignore brightness changes triggered by monitor hot-plug

### DIFF
--- a/lib/BrightnessDbus.js
+++ b/lib/BrightnessDbus.js
@@ -1,9 +1,14 @@
 import Gio from 'gi://Gio';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as FileUtils from 'resource:///org/gnome/shell/misc/fileUtils.js';
 import { CallbackManager } from './CallbackManager.js';
 
 const BUS_NAME = 'org.gnome.SettingsDaemon.Power';
 const OBJECT_PATH = '/org/gnome/SettingsDaemon/Power';
+
+// Window after a monitor topology change during which a brightness change
+// from GSD is treated as system-driven, not as a user preference adjustment.
+const MONITOR_CHANGE_SUPPRESS_MS = 1000;
 
 function roundTo(value, decimals) {
   const factor = Math.pow(10, decimals);
@@ -19,6 +24,8 @@ export class BrightnessDbus {
     this._requestedValue = null;
     this._requestedTime = null;
     this._graceTimeoutMs = 250;
+    this._suppressUserPrefUntil = 0;
+    this._monitorsChangedId = null;
     this.onBrightnessChange = new CallbackManager();
     this.onUserPreferenceChange = new CallbackManager();
   }
@@ -49,7 +56,8 @@ export class BrightnessDbus {
           brightness !== this._requestedValue &&
           Date.now() - this._requestedTime > this._graceTimeoutMs &&
           brightness > 0 &&
-          !this.isDimming
+          !this.isDimming &&
+          Date.now() >= this._suppressUserPrefUntil
         ) {
           this.onUserPreferenceChange.invoke(normalizedValue);
         } else {
@@ -57,6 +65,14 @@ export class BrightnessDbus {
         }
       }
     });
+
+    // Mutter republishes brightness when the monitor set changes; without
+    // this guard the next g-properties-changed would be misclassified as a
+    // manual user adjustment and pause the extension.
+    this._monitorsChangedId =
+      Main.layoutManager?.connect('monitors-changed', () => {
+        this._suppressUserPrefUntil = Date.now() + MONITOR_CHANGE_SUPPRESS_MS;
+      }) ?? null;
   }
 
   get brightness() {
@@ -96,6 +112,10 @@ export class BrightnessDbus {
     if (this._onChangeSignalId) {
       this._proxy?.disconnect(this._onChangeSignalId);
       this._onChangeSignalId = null;
+    }
+    if (this._monitorsChangedId) {
+      Main.layoutManager?.disconnect(this._monitorsChangedId);
+      this._monitorsChangedId = null;
     }
     this._proxy = null;
     this._dimmingTarget = null;

--- a/lib/BrightnessManager.js
+++ b/lib/BrightnessManager.js
@@ -1,6 +1,10 @@
 import * as Config from 'resource:///org/gnome/shell/misc/config.js';
 import { CallbackManager } from './CallbackManager.js';
 
+// Window after a monitor topology change during which a globalScale value
+// change is treated as system-driven, not as a user preference adjustment.
+const MONITOR_CHANGE_SUPPRESS_MS = 1000;
+
 // GNOME49 introduces new interface to manage brightness
 // https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/gnome-49/js/misc/brightnessManager.js?ref_type=heads
 export class BrightnessManager {
@@ -17,6 +21,7 @@ export class BrightnessManager {
     this._globalScaleSignalId = null;
     this._currentGlobalScale = null; // Keep reference for cleanup
     this._monitorScaleSignalIds = [];
+    this._suppressUserPrefUntil = 0;
     this.onBrightnessChange = new CallbackManager();
     this.onUserPreferenceChange = new CallbackManager();
   }
@@ -28,6 +33,11 @@ export class BrightnessManager {
   }
 
   _onMonitorChange() {
+    // A monitor topology change causes Mutter to republish brightness via
+    // globalScale; without this guard the next notify::value would be
+    // misclassified as a manual user adjustment and pause the extension.
+    this._suppressUserPrefUntil = Date.now() + MONITOR_CHANGE_SUPPRESS_MS;
+
     // Disconnect old monitor scale listeners
     // Important: Keep references to the old scale objects because this._manager.scales
     // returns a new array with potentially new objects when monitors change
@@ -50,6 +60,9 @@ export class BrightnessManager {
 
       if (!this._supportsBiasSlider) {
         this._globalScaleSignalId = this._currentGlobalScale.connect('notify::value', () => {
+          if (Date.now() < this._suppressUserPrefUntil) {
+            return;
+          }
           const userPreference = this._manager?.globalScale?.value ?? null;
           this.onUserPreferenceChange.invoke(userPreference);
         });

--- a/tests/BrightnessManager.test.js
+++ b/tests/BrightnessManager.test.js
@@ -345,14 +345,36 @@ describe('BrightnessManager', () => {
       it('should trigger user preference callbacks on globalScale changes', () => {
         const callback = jest.fn();
         manager.onUserPreferenceChange.add(callback);
-        
+
         manager.connect();
         Main.brightnessManager.emit('changed');
-        
-        // Change globalScale value - this should trigger the callback
-        Main.brightnessManager.globalScale.value = 0.8;
-        
+
+        // Step past the post-monitor-change suppression window so the next
+        // value change is treated as a real user adjustment.
+        const realNow = Date.now();
+        const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(realNow + 2000);
+        try {
+          Main.brightnessManager.globalScale.value = 0.8;
+        } finally {
+          nowSpy.mockRestore();
+        }
+
         expect(callback).toHaveBeenCalledWith(0.8);
+      });
+
+      it('should suppress user preference callbacks during the monitor-change window', () => {
+        const callback = jest.fn();
+        manager.onUserPreferenceChange.add(callback);
+
+        manager.connect();
+        Main.brightnessManager.emit('changed');
+
+        // Within the suppression window after a monitor change, a value
+        // change is treated as system-driven (e.g., Mutter republish) and
+        // must not be reported as a manual user adjustment.
+        Main.brightnessManager.globalScale.value = 0.8;
+
+        expect(callback).not.toHaveBeenCalled();
       });
     });
 

--- a/tests/__mocks__/Main.js
+++ b/tests/__mocks__/Main.js
@@ -151,6 +151,29 @@ export class BrightnessManager {
 
 export const messageTray = new MessageTray();
 
+// Minimal layoutManager mock — only the 'monitors-changed' signal is used.
+class LayoutManager {
+  constructor() {
+    this._callbacks = new Map();
+    this._nextId = 1;
+  }
+  connect(signal, cb) {
+    if (signal !== 'monitors-changed') return 0;
+    const id = this._nextId++;
+    this._callbacks.set(id, cb);
+    return id;
+  }
+  disconnect(id) {
+    this._callbacks.delete(id);
+  }
+  emit(signal) {
+    if (signal !== 'monitors-changed') return;
+    for (const cb of this._callbacks.values()) cb();
+  }
+}
+
+export const layoutManager = new LayoutManager();
+
 // Export brightnessManager instance (can be set to null to test legacy path)
 export let brightnessManager = new BrightnessManager();
 
@@ -165,5 +188,6 @@ export function resetBrightnessManager(enabled = true) {
 
 export default {
   messageTray,
+  layoutManager,
   brightnessManager,
 };


### PR DESCRIPTION
## Summary

Plugging/unplugging an external monitor showed "Automatic brightness
management is paused. Dismiss this notification to resume." until
dismissed.

Mutter/GSD republishes the brightness value when the monitor set
changes. The "user changed brightness" heuristic (timing + mismatch
against last-written value) can't tell that apart from a real slider/key
press, so it routed the event to `onUserPreferenceChange` and paused.

Fix: 1-second suppression window after a monitor topology change in
both backends. Inside the window, brightness changes go to
`onBrightnessChange` only.

- `BrightnessManager` (GNOME 49+): set `_suppressUserPrefUntil` in
  `_onMonitorChange()` and gate the `globalScale` `notify::value`
  handler. Only affects pre-49.2 builds (49.2+ already bypasses it).
- `BrightnessDbus` (GNOME 46-48): subscribe to
  `Main.layoutManager` `monitors-changed` and gate the user-preference
  branch of `g-properties-changed`.