### PR TITLE
Fix brightness not being applied on resume from sleep

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -66,8 +66,30 @@ export default class AdaptiveBrightnessExtension extends Extension {
       'prepare-for-sleep',
       (lm, aboutToSuspend) => {
         // Pause processing brightness during transitions from/to suspend
-        // Force an update on resume to handle lighting changes during sleep
         this.displayBrightness.paused = aboutToSuspend;
+
+        // On resume: force an update after a short delay to handle lighting
+        // changes during sleep. The delay lets mutter republish globalScale
+        // (GNOME 49+) and lets GSD finish its post-resume brightness restore
+        // (GNOME 46-48) before we apply the lux-derived target. Direct write
+        // bypasses the displayIsActive gate, which can be stale (cached dim
+        // value or null globalScale) right after resume.
+        if (!aboutToSuspend) {
+          if (this._resumeTimeoutId) {
+            GLib.source_remove(this._resumeTimeoutId);
+          }
+          this._resumeTimeoutId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 250, () => {
+            this._resumeTimeoutId = null;
+            const lux = this.sensorProxy?.dbus.lightLevel;
+            if (lux !== null && lux !== undefined && this.bucketMapper) {
+              const bucket = this.bucketMapper.mapLuxToBrightness(lux);
+              if (bucket && this.displayBrightness?.backend) {
+                this.displayBrightness.backend.brightness = bucket.brightness;
+              }
+            }
+            return GLib.SOURCE_REMOVE;
+          });
+        }
       }
     );
 
@@ -183,6 +205,11 @@ export default class AdaptiveBrightnessExtension extends Extension {
       this.sleepResumeSignalId = null;
     }
     this.loginManager = null;
+
+    if (this._resumeTimeoutId) {
+      GLib.source_remove(this._resumeTimeoutId);
+      this._resumeTimeoutId = null;
+    }
 
     if (this.bucketSettingsChangedId) {
       this.settings?.disconnect(this.bucketSettingsChangedId);


### PR DESCRIPTION
## Summary

On resume from sleep, the extension correctly read the ambient light level and computed the right target bucket, but the actual brightness was never written. Toggling the extension off and on fixed it.

## Root cause

The prepare-for-sleep handler only flipped `paused` and relied on `DisplayBrightnessService._processDisplayActiveState` to flip `displayIsActive` from `false` to `true`, which would in turn fire `onDisplayIsActiveChanged` and write the brightness. That chain breaks when the composite state is stale at resume time:

- **GNOME 46-48 (BrightnessDbus)**: GSD idle-dimmed before suspend, so the proxy's cached `Brightness` still equals `_dimmingTarget` on resume → `isDimming = true` → `displayIsActive` stuck at `false` → no callback, no write.
- **GNOME 49+ (BrightnessManager)**: mutter has not republished `globalScale` yet when `prepare-for-sleep(false)` arrives → brightness getter returns `null` → `displayIsOff = true` → `displayIsActive` stuck at `false` → no callback, no write.
- Even when the callback eventually did fire, it could race with GSD's own post-resume brightness restore.

## Fix

Schedule a `GLib.timeout_add(250ms)` on resume that reads `lightLevel` directly, maps to a bucket, and writes `displayBrightness.backend.brightness = bucket.brightness` without going through `adjustBrightnessForLightLevel`, so the `displayIsActive` early-return cannot veto it. Any pending resume timeout is cancelled before scheduling a new one, and `disable()` clears the pending timeout to avoid firing after teardown.

The 250ms delay gives mutter time to republish `globalScale` and gives GSD time to finish its own resume restore, so the write lands last and is not overwritten.