### PR TITLE
fix: re-claim light sensor on iio-sensor-proxy restart

### DIFF
--- a/lib/SensorProxyDbus.js
+++ b/lib/SensorProxyDbus.js
@@ -111,6 +111,30 @@ export class SensorProxyDbus {
   }
 
   /**
+   * Subscribe to bus name owner changes (daemon start/stop/restart)
+   * @param {Function} callback - Called with (proxy) when the owner changes
+   * @returns {number} Signal ID for disconnection
+   */
+  onNameOwnerChanged(callback) {
+    if (!this._proxy) {
+      throw new Error('D-Bus proxy not connected');
+    }
+
+    return this._proxy.connect('notify::g-name-owner', callback);
+  }
+
+  /**
+   * Current bus name owner, or null if the daemon is not running
+   * @returns {string|null}
+   */
+  get nameOwner() {
+    if (!this._proxy) {
+      return null;
+    }
+    return this._proxy.g_name_owner ?? null;
+  }
+
+  /**
    * Disconnect property change listener
    * @param {number} signalId - Signal ID returned from onPropertiesChanged
    */

--- a/lib/SensorProxyService.js
+++ b/lib/SensorProxyService.js
@@ -74,7 +74,11 @@ export class SensorProxyService {
     const lightLevel = changed.lookup_value('LightLevel', null);
     if (lightLevel) {
       const level = lightLevel.get_double();
-      this._handleLightLevelChange(level);
+      // iio-sensor-proxy publishes a phantom lux=0 right after resume
+      // before the sensor settles; the indoor noise floor is non-zero.
+      if (level !== 0) {
+        this._handleLightLevelChange(level);
+      }
     }
 
     // Also check HasAmbientLight property

--- a/lib/SensorProxyService.js
+++ b/lib/SensorProxyService.js
@@ -11,6 +11,8 @@ export class SensorProxyService {
     // D-Bus sensor proxy control
     this.dbus = new SensorProxyDbus();
     this._signalId = null;
+    this._nameOwnerSignalId = null;
+    this._currentNameOwner = null;
 
     // Filtering function: (previousLux, currentLux) => boolean
     this._filterFn = filterFn;
@@ -32,7 +34,33 @@ export class SensorProxyService {
   async start() {
     await this.dbus.connect();
     this._signalId = this.dbus.onPropertiesChanged(this._onPropertiesChanged.bind(this));
+    this._nameOwnerSignalId = this.dbus.onNameOwnerChanged(this._onNameOwnerChanged.bind(this));
+    this._currentNameOwner = this.dbus.nameOwner;
     await this.dbus.claimLight();
+  }
+
+  /**
+   * Handle iio-sensor-proxy daemon owner changes. The existing ClaimLight()
+   * dies with the old daemon, so when a new owner appears we must re-claim
+   * to keep receiving LightLevel updates.
+   */
+  _onNameOwnerChanged() {
+    const previousOwner = this._currentNameOwner;
+    const newOwner = this.dbus.nameOwner;
+    this._currentNameOwner = newOwner;
+
+    if (newOwner === null) {
+      return;
+    }
+
+    if (newOwner === previousOwner) {
+      return;
+    }
+
+    this._lastLuxValue = null;
+    this.dbus.claimLight().catch((e) => {
+      console.error('Failed to re-claim light sensor after daemon restart:', e);
+    });
   }
 
   /**
@@ -115,6 +143,11 @@ export class SensorProxyService {
     if (this.dbus && this._signalId) {
       this.dbus.disconnectListener(this._signalId);
       this._signalId = null;
+    }
+
+    if (this.dbus && this._nameOwnerSignalId) {
+      this.dbus.disconnectListener(this._nameOwnerSignalId);
+      this._nameOwnerSignalId = null;
     }
 
     // Release the light sensor


### PR DESCRIPTION
## Summary

When `iio-sensor-proxy` restarts, the extension keeps a stale `ClaimLight()` claim on the previous bus name owner and stops receiving `LightLevel` updates, leaving panel brightness frozen.

This is most visible on hardware where the ambient light sensor reads `lux = 0` briefly after resume from suspend (e.g. Framework laptops), since the typical workaround is a system service that restarts `iio-sensor-proxy` on resume — but it also covers daemon crashes and package upgrades unrelated to suspend/resume.

## Changes

- **Re-claim on daemon restart.** Subscribe to `notify::g-name-owner` on the `SensorProxy` `GDBusProxy`. When a new non-null owner appears, re-issue `ClaimLight()` and clear the cached last-lux so the next reading isn't filtered as a duplicate. Not gated on resume — daemon restarts happen in other contexts too.
- **Reject phantom `lux = 0` readings.** Defensive value filter in the `LightLevel` change handler. Indoor noise floors are non-zero, so an exact `0` is treated as the known `iio-sensor-proxy` phantom value and dropped without updating the cache or propagating to listeners. Acts as a safety net when the daemon-restart workaround isn't installed or hasn't fired yet.